### PR TITLE
fix for non-sparc sun machines

### DIFF
--- a/ext/salsa20_ext/ecrypt-config.h
+++ b/ext/salsa20_ext/ecrypt-config.h
@@ -9,6 +9,22 @@
 
 /* Guess the endianness of the target architecture. */
 
+/* First try to look for precompiler hints */
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) \
+    && defined(__ORDER_BIG_ENDIAN__)
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define ECRYPT_LITTLE_ENDIAN
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define ECRYPT_BIG_ENDIAN
+#endif
+
+#endif
+
+#if !defined(ECRYPT_BIG_ENDIAN) && !defined(ECRYPT_LITTLE_ENDIAN)
+
+/* No precompiler hints, fallback to best guess method */
+
 /* 
  * The LITTLE endian machines:
  */
@@ -30,10 +46,18 @@
 /* 
  * The BIG endian machines: 
  */
-#elif defined(sun)              /* Newer Sparc's */
-#define ECRYPT_BIG_ENDIAN
 #elif defined(__ppc__)          /* PowerPC */
 #define ECRYPT_BIG_ENDIAN
+
+/*
+ * Machines that can be either:
+ */
+#elif defined(sun)
+#if defined(__sparc)
+#define ECRYPT_BIG_ENDIAN
+#else
+#define ECRYPT_LITTLE_ENDIAN
+#endif
 
 /* 
  * Finally machines with UNKNOWN endianness:
@@ -51,6 +75,8 @@
 #else	                        /* Any other processor */
 #define ECRYPT_UNKNOWN
 #endif
+
+#endif /* if !defined(ECRYPT_LITTLE_ENDIAN) ... */
 
 /* ------------------------------------------------------------------------- */
 


### PR DESCRIPTION
I've been chasing a bug that started in rubywarden: https://github.com/jcs/rubywarden/issues/71

It led me to rubeepass: https://gitlab.com/mjwhitta/rubeepass/issues/3

Which led me here.

I'm testing on a [SmartOS](https://smartos.org) machine, which uses the [illumos](http://illumos.org) kernel, which is a fork from Open Solaris (so it looks like a Sun machine).

```
$ uname -a
SunOS arbiter.rapture.com 5.11 joyent_20180830T001556Z i86pc i386 i86pc Solaris
```

When I run the tests on the latest master branch I see:

```
$ rake test
/opt/local/bin/ruby22 -I"lib:test"  "/opt/local/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/salsa20_test.rb" 
Run options: --seed 6784

# Running:

.....F........

Finished in 0.311694s, 44.9159 runs/s, 118.7062 assertions/s.

  1) Failure:
Salsa20Test#test_salsa20_keystream [/home/dave/dev/salsa20-ruby/test/salsa20_test.rb:10]:
--- expected
+++ actual
@@ -1 +1 @@
-"@\x8D\x94\xF48f9Z)\e\xBD\xB8?\xCC\xEC\xD6g\xB3;\xC7ev\v\xCA]\xEE\x19I;\xA2<\\^\xCEFQn\x94B{+\x06\xE2\x85\x9F\xEC\xBBp@\xA4\x8F\xD8~\xD3\x12\x197\f\xD7'\x8C\xC8\xEF\xFC"
+"\x1Fp\x05;\xE5\xEE{%\x06\x12\xD8\xB1\xEB\x9C\xD7,\xEF=|\x89\x9C\x96%\xCE-\xF4\xE3hgMUq\xD0\xFCB\x97N\xC9_4\xE3\xFA\xA4\xC9\x17S\x8Es\xEBe\xC5\xF4;\xD7F\xC2\x04X\x18\xA7h\x06\xD46"


14 runs, 37 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1): [ruby -I"lib:test"  "/opt/local/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/salsa20_test.rb" ]
/opt/local/bin/rake22:33:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

I traced this to an error in how my architecture was being determined.  This patch will correctly identify and separate sparc machines from sun machines.

With this patch:

```
$ rake test
/opt/local/bin/ruby22 -I"lib:test"  "/opt/local/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/salsa20_test.rb" 
Run options: --seed 39109

# Running:

..............

Finished in 0.001385s, 10108.7850 runs/s, 26716.0746 assertions/s.

14 runs, 37 assertions, 0 failures, 0 errors, 0 skips
```

I was also able to test what type of machine it was determining I had with this test program:

```
$ cd ext/salsa20_ext
$ cat test.c 
#include "ecrypt-sync.h"
#include <stdio.h>

int main() {
#if defined(ECRYPT_LITTLE_ENDIAN)
printf("ECRYPT_LITTLE_ENDIAN\n");
#elif defined(ECRYPT_LITTLE_ENDIAN)
printf("ECRYPT_LITTLE_ENDIAN\n");
#else
printf("UNKNOWN\n");
#endif
}
$ cc test.c salsa20.c 
$ ./a.out 
ECRYPT_LITTLE_ENDIAN
```
